### PR TITLE
Support minification options

### DIFF
--- a/cjs/ucontent.js
+++ b/cjs/ucontent.js
@@ -125,7 +125,7 @@ class SVG extends UContent {
       cache.get(this) ||
       cache.set(
         this,
-        new SVG(html.minify(this.toString(), {...svgOptions, options}), true)
+        new SVG(html.minify(this.toString(), {...svgOptions, ...options}), true)
       )
     );
   }

--- a/cjs/ucontent.js
+++ b/cjs/ucontent.js
@@ -66,12 +66,12 @@ class HTML extends UContent {
   /**
    * @returns {HTML} The HTML instance as minified.
    */
-  min() {
+  min(options) {
     return this.minified ? this : (
       cache.get(this) ||
       cache.set(
         this,
-        new HTML(html.minify(this.toString(), htmlOptions), true)
+        new HTML(html.minify(this.toString(), {...htmlOptions, ...options}), true)
       )
     );
   }
@@ -86,12 +86,12 @@ class JS extends UContent {
   /**
    * @returns {JS} The JS instance as minified.
    */
-  min() {
+  min(options) {
     return this.minified ? this : (
       cache.get(this) ||
       cache.set(
         this,
-        new JS(Terser.minify(this.toString(), jsOptions).code, true)
+        new JS(Terser.minify(this.toString(), {...jsOptions, ...options}).code, true)
       )
     );
   }
@@ -120,12 +120,12 @@ class SVG extends UContent {
   /**
    * @returns {SVG} The SVG instance as minified.
    */
-  min() {
+  min(options) {
     return this.minified ? this : (
       cache.get(this) ||
       cache.set(
         this,
-        new SVG(html.minify(this.toString(), svgOptions), true)
+        new SVG(html.minify(this.toString(), {...svgOptions, options}), true)
       )
     );
   }

--- a/cjs/utils.js
+++ b/cjs/utils.js
@@ -12,7 +12,7 @@ const {assign, keys} = Object;
 
 const inlineStyle = umap(new WeakMap);
 
-const prefix = 'isµ' + Date.now();
+const prefix = 'isµ';// + Date.now();
 const interpolation = new RegExp(
   `(<!--${prefix}(\\d+)-->|\\s*${prefix}(\\d+)=('|")([^\\4]+?)\\4)`, 'g'
 );

--- a/cjs/utils.js
+++ b/cjs/utils.js
@@ -59,11 +59,11 @@ const getValue = value => {
   return value == null ? '' : escape(String(value));
 };
 
-const minify = ($, svg) => html.minify($, svg ? svgOptions : htmlOptions);
+const minify = ($, svg, options) => html.minify($, svg ? {...svgOptions, ...options} : {...htmlOptions, ...options});
 
 const parse = (template, expectedLength, svg, minified) => {
   const text = instrument(template, prefix, svg);
-  const html = minified ? minify(text, svg) : text;
+  const html = minified ? minify(text, svg, minified) : text;
   const updates = [];
   let i = 0;
   let match = null;

--- a/cjs/utils.js
+++ b/cjs/utils.js
@@ -12,7 +12,7 @@ const {assign, keys} = Object;
 
 const inlineStyle = umap(new WeakMap);
 
-const prefix = 'isµ';// + Date.now();
+const prefix = 'isµ' + Date.now();
 const interpolation = new RegExp(
   `(<!--${prefix}(\\d+)-->|\\s*${prefix}(\\d+)=('|")([^\\4]+?)\\4)`, 'g'
 );

--- a/esm/ucontent.js
+++ b/esm/ucontent.js
@@ -120,7 +120,7 @@ export class SVG extends UContent {
       cache.get(this) ||
       cache.set(
         this,
-        new SVG(html.minify(this.toString(), {...svgOptions, options}), true)
+        new SVG(html.minify(this.toString(), {...svgOptions, ...options}), true)
       )
     );
   }

--- a/esm/ucontent.js
+++ b/esm/ucontent.js
@@ -64,12 +64,12 @@ export class HTML extends UContent {
   /**
    * @returns {HTML} The HTML instance as minified.
    */
-  min() {
+  min(options) {
     return this.minified ? this : (
       cache.get(this) ||
       cache.set(
         this,
-        new HTML(html.minify(this.toString(), htmlOptions), true)
+        new HTML(html.minify(this.toString(), {...htmlOptions, ...options}), true)
       )
     );
   }
@@ -83,12 +83,12 @@ export class JS extends UContent {
   /**
    * @returns {JS} The JS instance as minified.
    */
-  min() {
+  min(options) {
     return this.minified ? this : (
       cache.get(this) ||
       cache.set(
         this,
-        new JS(Terser.minify(this.toString(), jsOptions).code, true)
+        new JS(Terser.minify(this.toString(), {...jsOptions, ...options}).code, true)
       )
     );
   }
@@ -115,12 +115,12 @@ export class SVG extends UContent {
   /**
    * @returns {SVG} The SVG instance as minified.
    */
-  min() {
+  min(options) {
     return this.minified ? this : (
       cache.get(this) ||
       cache.set(
         this,
-        new SVG(html.minify(this.toString(), svgOptions), true)
+        new SVG(html.minify(this.toString(), {...svgOptions, options}), true)
       )
     );
   }

--- a/esm/utils.js
+++ b/esm/utils.js
@@ -11,7 +11,7 @@ const {assign, keys} = Object;
 
 const inlineStyle = umap(new WeakMap);
 
-const prefix = 'isµ' + Date.now();
+const prefix = 'isµ';// + Date.now();
 const interpolation = new RegExp(
   `(<!--${prefix}(\\d+)-->|\\s*${prefix}(\\d+)=('|")([^\\4]+?)\\4)`, 'g'
 );

--- a/esm/utils.js
+++ b/esm/utils.js
@@ -58,11 +58,11 @@ const getValue = value => {
   return value == null ? '' : escape(String(value));
 };
 
-const minify = ($, svg) => html.minify($, svg ? svgOptions : htmlOptions);
+const minify = ($, svg, options) => html.minify($, svg ? {...svgOptions, ...options} : {...htmlOptions, ...options});
 
 export const parse = (template, expectedLength, svg, minified) => {
   const text = instrument(template, prefix, svg);
-  const html = minified ? minify(text, svg) : text;
+  const html = minified ? minify(text, svg, minified) : text;
   const updates = [];
   let i = 0;
   let match = null;

--- a/esm/utils.js
+++ b/esm/utils.js
@@ -11,7 +11,7 @@ const {assign, keys} = Object;
 
 const inlineStyle = umap(new WeakMap);
 
-const prefix = 'isµ';// + Date.now();
+const prefix = 'isµ' + Date.now();
 const interpolation = new RegExp(
   `(<!--${prefix}(\\d+)-->|\\s*${prefix}(\\d+)=('|")([^\\4]+?)\\4)`, 'g'
 );

--- a/test/implicit-min.js
+++ b/test/implicit-min.js
@@ -1,0 +1,26 @@
+const {render, html} = require('../cjs');
+
+html.minified = { removeComments: false }
+
+require('http').createServer((req, res) => {
+  res.writeHead(200, {'content-type': 'text/html;charset=utf-8'});
+  render(content => res.end(content), html`
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>ucontent</title>
+    </head>
+    <body>${html`
+      <h1>Hello There</h1>
+      <!-- Hello from comments -->
+      <p>
+        Thank you for visiting uhtml at ${new Date()}
+      </p>
+    `}</body>
+    </html>
+  `);
+}).listen(8080);
+
+console.log('http://localhost:8080/');

--- a/test/min-options.js
+++ b/test/min-options.js
@@ -1,0 +1,24 @@
+const {render, html} = require('../cjs');
+
+require('http').createServer((req, res) => {
+  res.writeHead(200, {'content-type': 'text/html;charset=utf-8'});
+  render(content => res.end(content), html`
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>ucontent</title>
+    </head>
+    <body>${html`
+      <h1>Hello There</h1>
+      <!-- Hello from comments -->
+      <p>
+        Thank you for visiting uhtml at ${new Date()}
+      </p>
+    `}</body>
+    </html>
+  `.min({ removeComments: false }));
+}).listen(8080);
+
+console.log('http://localhost:8080/');


### PR DESCRIPTION
Optionally pass in options to `.min()` for html-minifier and terser. Also allows for setting options via implicit minification: 
```js
html.minified = { removeComments: false }
return html`
 <h1>Hello</h1>
 <!-- Hello -->
`

// OR

return html`
 <h1>Hello</h1>
 <!-- Hello -->
`.min({ removeComments: false })
```
Default options will be used just as before if no extra options are specified.

```js
// Still works
html.minified = true
return html`
 <h1>Hello</h1>
`
// Still works
return html`
 <h1>Hello</h1>
`.min()
```

